### PR TITLE
fix(ewma): reduce the chances of fake bandwidth spikes

### DIFF
--- a/sweeper.go
+++ b/sweeper.go
@@ -107,6 +107,12 @@ func (sw *sweeper) update() {
 		}
 		return
 	} else if tdiff <= ewmaRate/10 {
+		// If the time-delta is too small, wait a bit. Otherwise, we can end up logging a
+		// very large spike.
+		//
+		// This won't fix the case where a user passes a large update (spanning multiple
+		// seconds) to `Meter.Mark`, but it will fix the case where the system fails to
+		// accurately schedule the sweeper goroutine.
 		return
 	}
 


### PR DESCRIPTION
Ignore updates that are less than 100ms. Otherwise, we could attribute a large amount of bandwidth to a very short period of time and get a _huge_ spike.

The next step will be to split writes up into chunks _before_ we get to the meter.

An alternative is to record the amount of data sent and a time. However, the
current system was chosen precisely to avoid repeatedly asking for the time.