### PR TITLE
chore: skip slow tests when short testing is specified

### DIFF
--- a/flow_test.go
+++ b/flow_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestBasic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short testing requested")
+	}
 	var wg sync.WaitGroup
 	wg.Add(100)
 	for i := 0; i < 100; i++ {
@@ -52,6 +55,9 @@ func TestBasic(t *testing.T) {
 }
 
 func TestShared(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short testing requested")
+	}
 	var wg sync.WaitGroup
 	wg.Add(20 * 21)
 	for i := 0; i < 20; i++ {
@@ -102,6 +108,9 @@ func TestShared(t *testing.T) {
 }
 
 func TestUnregister(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short testing requested")
+	}
 	var wg sync.WaitGroup
 	wg.Add(100 * 2)
 	for i := 0; i < 100; i++ {

--- a/sweeper_test.go
+++ b/sweeper_test.go
@@ -7,6 +7,10 @@ import (
 
 // regression test for libp2p/go-libp2p-core#65
 func TestIdleInconsistency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short testing requested")
+	}
+
 	r := new(MeterRegistry)
 	m1 := r.Get("first")
 	m2 := r.Get("second")
@@ -40,5 +44,4 @@ func TestIdleInconsistency(t *testing.T) {
 	if total := r.Get("third").Snapshot().Total; total != 50 {
 		t.Errorf("expected third total to be 50, got %d", total)
 	}
-
 }


### PR DESCRIPTION
Experimented with using t.Parallel() to run slow tests concurrently but this increased the frequency of flaky failures.