### PR TITLE
feat(test): add mock clock API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-  - 1.13.x
+  - 1.15.x
 
 env:
   global:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/libp2p/go-flow-metrics
 
-go 1.12
+go 1.15
+
+require github.com/benbjohnson/clock v1.3.0

--- a/sweeper.go
+++ b/sweeper.go
@@ -75,12 +75,7 @@ func (sw *sweeper) stop() {
 
 func (sw *sweeper) run(ctx context.Context) {
 	defer close(sw.stopped)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
+	for ctx.Err() == nil {
 		select {
 		case m := <-sw.registerChannel:
 			sw.register(m)


### PR DESCRIPTION
Went with a more specialized `UseMockClock` API to clearly signal this is for tests and not something you normally mess with but can revert to the more general `SetClock` if preferred.

Closes https://github.com/libp2p/go-flow-metrics/issues/17.