### PR TITLE
introduce an API to set a mock clock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-  - 1.13.x
+  - 1.17.x
 
 env:
   global:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/libp2p/go-flow-metrics
 
-go 1.12
+go 1.17
+
+require github.com/benbjohnson/clock v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/mockclocktest/mock_clock_test.go
+++ b/mockclocktest/mock_clock_test.go
@@ -1,0 +1,43 @@
+package mockclocktest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-flow-metrics"
+
+	"github.com/benbjohnson/clock"
+)
+
+var cl = clock.NewMock()
+
+func init() {
+	flow.SetClock(cl)
+}
+
+func TestBasic(t *testing.T) {
+	m := new(flow.Meter)
+	for i := 0; i < 300; i++ {
+		m.Mark(1000)
+		cl.Add(40 * time.Millisecond)
+	}
+	if rate := m.Snapshot().Rate; rate != 25000 {
+		t.Errorf("expected rate 25000, got %f", rate)
+	}
+
+	for i := 0; i < 200; i++ {
+		m.Mark(200)
+		cl.Add(40 * time.Millisecond)
+	}
+
+	// Adjusts
+	if rate := m.Snapshot().Rate; rate != 5017.776503840969 {
+		t.Errorf("expected rate 5017.776503840969, got %f", rate)
+	}
+
+	// Let it settle.
+	cl.Add(2 * time.Second)
+	if total := m.Snapshot().Total; total != 340000 {
+		t.Errorf("expected total 3400000, got %d", total)
+	}
+}


### PR DESCRIPTION
Fixes #17. Closes #18.

This should be significantly easier than #18. It only adds a `SetClock` function, and no way to switch out the clock. That means that in tests, you have to define a global clock variable (and not a separate clock for every test).

This also means that I had to create a new testing package to test the mock clock. At some point, we probably should rewrite the tests to take advantage of the mock clock, but this will be a larger undertaking, especially since registering a new meter is not done synchronously (it's put in the `registerChannel`, and picked up by the sweeper _eventually_), which makes it impossible to know when to advance the clock.
In https://github.com/libp2p/go-libp2p-core/pull/276/files#diff-3dda9486f00364eaac26b64ff16560cde7b6cf8ff03eda4de9752f0fb0a96f42R130, I work around this by sleeping for a short while.