### PR TITLE
chore: switch to typed atomics

### DIFF
--- a/flow_test.go
+++ b/flow_test.go
@@ -3,7 +3,6 @@ package flow
 import (
 	"math"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -106,7 +105,7 @@ func TestUnregister(t *testing.T) {
 
 	mockClock.Add(62 * time.Second)
 
-	if atomic.LoadUint64(&m.accumulator) != 0 {
+	if m.accumulator.Load() != 0 {
 		t.Error("expected meter to be paused")
 	}
 
@@ -131,7 +130,7 @@ func TestUnregister(t *testing.T) {
 	if actual.Total != 120 {
 		t.Errorf("expected total 120, got %d", actual.Total)
 	}
-	if atomic.LoadUint64(&m.accumulator) == 0 {
+	if m.accumulator.Load() == 0 {
 		t.Error("expected meter to be active")
 	}
 

--- a/meter.go
+++ b/meter.go
@@ -31,7 +31,7 @@ func (s Snapshot) String() string {
 
 // Meter is a meter for monitoring a flow.
 type Meter struct {
-	accumulator uint64
+	accumulator atomic.Uint64
 
 	// managed by the sweeper loop.
 	registered bool
@@ -42,7 +42,7 @@ type Meter struct {
 
 // Mark updates the total.
 func (m *Meter) Mark(count uint64) {
-	if count > 0 && atomic.AddUint64(&m.accumulator, count) == count {
+	if count > 0 && m.accumulator.Add(count) == count {
 		// The accumulator is 0 so we probably need to register. We may
 		// already _be_ registered however, if we are, the registration
 		// loop will notice that `m.registered` is set and ignore us.
@@ -60,7 +60,7 @@ func (m *Meter) Snapshot() Snapshot {
 // Reset sets accumulator, total and rate to zero.
 func (m *Meter) Reset() {
 	globalSweeper.snapshotMu.Lock()
-	atomic.StoreUint64(&m.accumulator, 0)
+	m.accumulator.Store(0)
 	m.snapshot.Rate = 0
 	m.snapshot.Total = 0
 	globalSweeper.snapshotMu.Unlock()


### PR DESCRIPTION
This just means we can be less concerned about struct field ordering and other details.