### PR TITLE
go-clock migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/libp2p/go-flow-metrics
 
 go 1.23
 
-require github.com/benbjohnson/clock v1.3.0
+require github.com/filecoin-project/go-clock v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
-github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/filecoin-project/go-clock v0.1.0 h1:SFbYIM75M8NnFm1yMHhN9Ahy3W5bEZV9gd6MPfXbKVU=
+github.com/filecoin-project/go-clock v0.1.0/go.mod h1:4uB/O4PvOjlx1VCMdZ9MyDZXRm//gkj1ELEbxfI1AZs=

--- a/sweeper.go
+++ b/sweeper.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benbjohnson/clock"
+	"github.com/filecoin-project/go-clock"
 )
 
 // IdleRate the rate at which we declare a meter idle (and stop tracking it

--- a/sweeper_test.go
+++ b/sweeper_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benbjohnson/clock"
+	"github.com/filecoin-project/go-clock"
 )
 
 var mockClock = clock.NewMock()


### PR DESCRIPTION
* [`github.com/benbjohnson/clock`](https://github.com/benbjohnson/clock) has been archived 2 years ago
* Migrate to the maintained fork [`github.com/filecoin-project/go-clock`](https://github.com/filecoin-project/go-clock)

References:
* https://github.com/libp2p/go-libp2p/issues/3289